### PR TITLE
ゲストユーザログイン（かんたんログイン）機能の実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  before_action :check_guest, only: :destroy
 
   # GET /resource/sign_up
   # def new
@@ -28,6 +29,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def destroy
   #   super
   # end
+
+  def check_guest
+    if resource.email == 'guest@guest.com'
+      redirect_to edit_user_registration_path, alert: 'ゲストユーザーアカウントは削除できません。'
+    end
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,6 +13,12 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def new_guest
+    user = User.guest
+    sign_in user
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました'
+  end
+
   # DELETE /resource/sign_out
   # def destroy
   #   super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,14 @@ class User < ApplicationRecord
   has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id'
   has_many :followers, through: :reverse_of_relationships, source: :user, dependent: :destroy
 
+  def self.guest
+    find_or_create_by!(email: 'guest@guest.com') do |user|
+      user.password = SecureRandom.alphanumeric
+      user.password_confirmation = user.password
+      user.name = "ゲストくんさん"
+    end
+  end
+
   def postcount
     Post.where(user_id: id).count
   end

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -43,7 +43,7 @@
             ログアウト
       - else
         %li
-          = link_to('#') do
+          = link_to(users_guest_sign_in_path, method: :post) do
             %i.fas.fa-user-check
             かんたんログイン
         - if current_page?(new_user_session_path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   get 'users/show'
   devise_for :users, controllers: { registrations: 'users/registrations' }
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#new_guest'
+  end
   root 'posts#index'
 
   resources :users, only: [:index, :show] do


### PR DESCRIPTION
# What
ユーザ登録を行わずとも、ワンクリックでゲスト用アカウントにログインできる「かんたん」ログイン機能を実装した。
通常のユーザとの差異は以下の通り。
- アカウントの削除ができない
- パスワードの変更ができない

# Why
機能確認のみを行いたい場合に新規ユーザ登録を行うのはユーザに負担がかかるため。