### PR TITLE
Users,Postsテーブルの不要な項目を削除

### DIFF
--- a/db/migrate/20210211121739_remove_from_users.rb
+++ b/db/migrate/20210211121739_remove_from_users.rb
@@ -1,0 +1,8 @@
+class RemoveFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :posts_count, :bigint
+    remove_column :users, :following_count, :bigint
+    remove_column :users, :followers_count, :bigint
+    remove_column :users, :likes_count, :bigint
+  end
+end

--- a/db/migrate/20210211122239_remove_from_posts.rb
+++ b/db/migrate/20210211122239_remove_from_posts.rb
@@ -1,0 +1,7 @@
+class RemoveFromPosts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :posts, :repost_count, :bigint
+    remove_column :posts, :comments_count, :bigint
+    remove_column :posts, :likes_count, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_28_052654) do
+ActiveRecord::Schema.define(version: 2021_02_11_122239) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -54,12 +54,9 @@ ActiveRecord::Schema.define(version: 2020_12_28_052654) do
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "text"
-    t.bigint "likes_count", default: 0
-    t.bigint "repost_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.bigint "comments_count", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -102,10 +99,6 @@ ActiveRecord::Schema.define(version: 2020_12_28_052654) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.text "description"
-    t.bigint "posts_count", default: 0
-    t.bigint "following_count", default: 0
-    t.bigint "followers_count", default: 0
-    t.bigint "likes_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
不要となった以下テーブル項目をテーブルから削除した。
- Users
  - posts_count
  - following_count
  - followers_count
  - likes_count
- Posts
  - repost_count
  - comments_count
  - likes_count

# Why
実装当初はユーザの投稿数など必要となると考えテーブル項目として実装したが、
各モデルのクラスメソッドで取得可能でありテーブル項目としては不要であることが分かったため。